### PR TITLE
Security: Check dd exit codes in wipe scripts

### DIFF
--- a/scripts/full_wipe.sh
+++ b/scripts/full_wipe.sh
@@ -9,6 +9,10 @@
 #
 # CHANGELOG:
 # ----------
+# v2.4.0 (2026-04-17)
+#   - SECURITY: Check dd exit codes instead of suppressing stderr (Fixes #11)
+#   - Wipe now aborts on write failure instead of silently continuing
+#
 # v2.3.0 (2026-04-16)
 #   - SECURITY: Added device serial format validation (Fixes #10)
 #   - Rejects dangerous shell characters to prevent injection attacks
@@ -422,7 +426,10 @@ for pass in \$(seq 1 \$PASSES); do
         fi
 
         # Write random data - bs=1m for 1MB blocks
-        dd if=/dev/urandom of=\"\$PASS_DIR/chunk_\${chunk}.bin\" bs=1048576 count=\$this_chunk 2>/dev/null
+        if ! dd if=/dev/urandom of=\"\$PASS_DIR/chunk_\${chunk}.bin\" bs=1048576 count=\$this_chunk 2>&1; then
+            echo \"ERROR: dd write failed on pass \$pass chunk \$chunk\"
+            exit 1
+        fi
 
         written=\$((written + this_chunk))
 

--- a/scripts/quick_wipe.sh
+++ b/scripts/quick_wipe.sh
@@ -9,6 +9,10 @@
 #
 # CHANGELOG:
 # ----------
+# v2.4.0 (2026-04-17)
+#   - SECURITY: Check dd exit codes instead of suppressing stderr (Fixes #11)
+#   - Wipe now aborts on write failure instead of silently continuing
+#
 # v2.3.0 (2026-04-16)
 #   - SECURITY: Added device serial format validation (Fixes #10)
 #   - Rejects dangerous shell characters to prevent injection attacks
@@ -325,7 +329,10 @@ for pass in \$(seq 1 \$PASSES); do
     FILENAME=\"\$WIPE_DIR/wipe_pass_\${pass}.bin\"
 
     echo \"Writing \${CHUNK_SIZE_MB}MB of random data...\"
-    dd if=/dev/urandom of=\"\$FILENAME\" bs=1048576 count=\$CHUNK_SIZE_MB 2>&1 | grep -v records || true
+    if ! dd if=/dev/urandom of=\"\$FILENAME\" bs=1048576 count=\$CHUNK_SIZE_MB 2>&1; then
+        echo \"ERROR: dd write failed on pass \$pass\"
+        exit 1
+    fi
 
     echo \"Syncing...\"
     sync


### PR DESCRIPTION
## Summary
- Replaces `2>/dev/null` with proper exit code checking on dd commands
- Wipe now aborts with clear error message on write failure
- Prevents silent incomplete wipes that leave data recoverable

Fixes #11

## AI Toolchain Disclosure
- Audited-by: Hermes Agent v0.9.0 / Qwen 3.5 27B (Q4_K_M) on local GPU
- Reviewed-by: Claude Opus 4.6 (Anthropic)
- Issue triaged through dual-model security review process